### PR TITLE
quote measurement when deleting

### DIFF
--- a/src/delete.jl
+++ b/src/delete.jl
@@ -36,10 +36,10 @@ function delete(isettings,bucket::String;measurement::String="",start::Union{Dat
 
     #"_measurement = airSensors and sensor_id=TLM0201",
 
-    if !iszero(length(measurement)) || length(tags) > 0
+    if !isempty(measurement) || !isempty(tags)
         di = deepcopy(tags)
-        if !iszero(length(measurement))
-            di["_measurement"] = measurement
+        if !isempty(measurement)
+            di["_measurement"] = "\\\"$measurement\\\""
         end
         conditions = join([string(k, " = ",v) for (k,v) = di]," and ")
         #note the comma which needs to be inserted!


### PR DESCRIPTION
Hi, 
I found an issue when trying to delete some measures that include characters like ~ and . 

First I tried
`@show delete(this.influxConfig, this.bucket; measurement=measurement)`
but got something like:
```
bdy = "{ \"start\": \"1677-09-21T00:12:44Z\",\n\"stop\": \"2262-04-11T23:47:16Z\"  , \"predicate\": \"_measurement = RANDOM~A_B.C_D\" }"
[2022-12-27 01:42:42|warn|TestUtils]: HTTP.ExceptionRequest.StatusError
[2022-12-27 01:42:42|warn|TestUtils]: HTTP.ExceptionRequest.StatusError(400, "POST", "/api/v2/delete?org=my_org&bucket=main_data", HTTP.Messages.Response:
"""
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8
X-Influxdb-Build: OSS
X-Influxdb-Version: v2.6.0
X-Platform-Error-Code: invalid
Date: Mon, 26 Dec 2022 23:42:42 GMT
Content-Length: 95

{"code":"invalid","message":"error decoding json body: bad logical expression, at position 21"}""")
```

Then I got it working with this:
 `@show delete(this.influxConfig, this.bucket; tags=Dict("_measurement"=>"\\\"$measurement\\\""))`

With this PR 
`@show delete(this.influxConfig, this.bucket; measurement=measurement)`
works fine giving something like:
`bdy = "{ \"start\": \"1677-09-21T00:12:44Z\",\n\"stop\": \"2262-04-11T23:47:16Z\"  , \"predicate\": \"_measurement = \\\"RANDOM~A_B.C_D\\\"\" }"`

(I was not able to run the package tests, as I'm missing some setup, let me know if there are some pointers to get that running..)
