### PR TITLE
Feature/support range start with stop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InfluxDBClient"
 uuid = "7a087161-7d97-4627-bbdd-0c82161d9408"
 authors = ["bernhard.koenig"]
-version = "0.0.4"
+version = "0.0.5"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InfluxDBClient"
 uuid = "7a087161-7d97-4627-bbdd-0c82161d9408"
 authors = ["bernhard.koenig"]
-version = "0.0.5"
+version = "0.0.4"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/README.md
+++ b/README.md
@@ -103,3 +103,36 @@ df_result = query_flux(isettings,a_random_bucket_name,"xxmeasurment";tzstr = "Eu
 #deleting a bucket
 delete_bucket(isettings,a_random_bucket_name)
 ```
+
+## Running tests
+
+First make sure you have the following environment variables defined:
+
+```Julia
+ENV["INFLUXDB_HOST"]="localhost:8086"
+ENV["INFLUXDB_ORG"]="<some org>"
+ENV["INFLUXDB_TOKEN"]="5Ixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=="
+ENV["INFLUXDB_USER"]="<admin user>"
+ENV["INFLUXDB_PASSWORD"]="<password>"
+```
+
+With newer influx versions, it can be hard to get an admin user that can create and drop buckets
+`sudo influx auth create --all-access -u <admin user> -o <some org>`
+For more information, see: <https://github.com/influxdata/influx-cli/issues/231>
+
+The easiest is to run via `]test` or `Pkg.test()`
+
+But in order to run `runtests.jl` or individual tests manually you need to activate the test dependencies,
+and since this is still has Julia 1 compatibility, we need to use the following method:
+
+```Julia
+]activate
+using TestEnv
+TestEnv.activate("InfluxDBClient")
+```
+
+For more information, see: 
+    <https://discourse.julialang.org/t/activating-test-dependencies/48121/10>
+    <https://github.com/JuliaTesting/TestEnv.jl>
+
+also had to modify runtents.jl line 47 to not add "test/"

--- a/src/query.jl
+++ b/src/query.jl
@@ -33,6 +33,7 @@ function query_flux(isettings,bucket,measurement;parse_datetime=false,datetime_p
             rangeUTC[k] = v
         end
     end
+    @show rangeUTC
 
     #perform query
     bdy = query_flux_http_response(isettings,bucket,measurement,range=rangeUTC,fields=fields,tags=tags,aggregate=aggregate)
@@ -135,7 +136,7 @@ function query_flux_http_response(isettings,bucket,measurement;range=Dict{String
                 rngstr = string(k,": ",v)
             end
         end
-        rngstr = string("range(",rngstr,")")
+        @show rngstr = string("range(",rngstr,")")
     end
     
     q = """from(bucket: "$(bucket)")"""

--- a/src/query.jl
+++ b/src/query.jl
@@ -33,7 +33,6 @@ function query_flux(isettings,bucket,measurement;parse_datetime=false,datetime_p
             rangeUTC[k] = v
         end
     end
-    @show rangeUTC
 
     #perform query
     bdy = query_flux_http_response(isettings,bucket,measurement,range=rangeUTC,fields=fields,tags=tags,aggregate=aggregate)
@@ -137,7 +136,7 @@ function query_flux_http_response(isettings,bucket,measurement;range=Dict{String
             end
             count += 1
         end
-        @show rngstr = string("range(",rngstr,")")
+        rngstr = string("range(",rngstr,")")
     end
     
     q = """from(bucket: "$(bucket)")"""

--- a/src/query.jl
+++ b/src/query.jl
@@ -127,14 +127,15 @@ function query_flux_http_response(isettings,bucket,measurement;range=Dict{String
         count = 0
         for (k,v) in range
             if count > 0 
-                rngstr = string(rngstr," and ")
+                rngstr *= ", "
             end
             #if v is a Date or DateTime add "+00:00" (UTC)
             if typeof(v) <: Dates.AbstractTime
-                rngstr = string(k,": ",v,"+00:00")
+                rngstr *= string(k,": ", v, "Z")
             else
-                rngstr = string(k,": ",v)
+                rngstr *= string(k,": ", v)
             end
+            count += 1
         end
         @show rngstr = string("range(",rngstr,")")
     end

--- a/test/query.jl
+++ b/test/query.jl
@@ -67,18 +67,15 @@
 
     datetime_str0 = string(DateTime(2022,9,30,15,59,33,0)-Hour(100),"+00:00")
     df2 = query_flux(isettings,a_random_bucket_name,"my_meas";tzstr = "Europe/Berlin",range=Dict("start"=>adt),fields=["temperature","humidity"],tags=Dict("color"=>"blue"),aggregate=agg);
-    @show df2
     @test size(df2) == (28,10)
 
     df2 = query_flux(isettings,a_random_bucket_name,"my_meas";tzstr = "Europe/Berlin",range=Dict("start"=>adt, "stop"=>adt+Minute(21)),fields=["temperature","humidity"],tags=Dict("color"=>"blue"),aggregate=agg);
-    @show df2
     @test size(df2) == (12,10)
 
-
-
-    ######################################################
+    
     ######################################################
     #parsing DateTime
+    ######################################################
     for _ in 1:nmax_repeat_selected_query_tests
         for selected_precision in reverse(PRECISIONS)
             @info("Query (query_flux_http_response) - Testing precision roundtrip for precision = $(selected_precision)...")

--- a/test/query.jl
+++ b/test/query.jl
@@ -65,9 +65,20 @@
     df2 = query_flux(isettings,a_random_bucket_name,"my_meas";tzstr = "Europe/Berlin",range=Dict("start"=>"$datetime_str"),fields=["temperature","humidity"],tags=Dict("color"=>"blue"),aggregate=agg);
     @test size(df2) == (36,10)
 
+    datetime_str0 = string(DateTime(2022,9,30,15,59,33,0)-Hour(100),"+00:00")
+    df2 = query_flux(isettings,a_random_bucket_name,"my_meas";tzstr = "Europe/Berlin",range=Dict("start"=>adt),fields=["temperature","humidity"],tags=Dict("color"=>"blue"),aggregate=agg);
+    @show df2
+    @test size(df2) == (28,10)
+
+    df2 = query_flux(isettings,a_random_bucket_name,"my_meas";tzstr = "Europe/Berlin",range=Dict("start"=>adt, "stop"=>adt+Minute(21)),fields=["temperature","humidity"],tags=Dict("color"=>"blue"),aggregate=agg);
+    @show df2
+    @test size(df2) == (12,10)
+
+
+
+    ######################################################
     ######################################################
     #parsing DateTime
-    ######################################################
     for _ in 1:nmax_repeat_selected_query_tests
         for selected_precision in reverse(PRECISIONS)
             @info("Query (query_flux_http_response) - Testing precision roundtrip for precision = $(selected_precision)...")


### PR DESCRIPTION
hi, 
I picked up a bug while trying to specify a stop value when querying eg:

    df2 = query_flux(isettings,a_random_bucket_name,"my_meas";tzstr = "Europe/Berlin",range=Dict("start"=>adt, **"stop"=>adt+Minute(21)**),fields=["temperature","humidity"],tags=Dict("color"=>"blue"),aggregate=agg);

I finally managed to run the tests after some struggles. To make it easier for the next guy, I added info in the `README.md`, feel free to correct/improve it.

thanks