### PR TITLE
Feature/support https

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
           JULIA_NUM_THREADS: 4          
           #must include PORT too here:
           #The hostname of the PostgreSQL service is the label you configured in your workflow, in this case, postgres. Because Docker containers on the same user-defined bridge network open all ports by default, you'll be able to access the service container on the default PostgreSQL port 5432.
-          INFLUXDB_HOST: localhost:8086
-          INFLUXDB_URL: http://localhost:8086
+          INFLUXDB_HOST: 0.0.0.0:8086
+          INFLUXDB_URL: http://0.0.0.0:8086
           INFLUXDB_ORG: ${{ secrets.INFLUXDB_ORG }}
           INFLUXDB_USER: ${{ secrets.INFLUXDB_USER }}
           INFLUXDB_PASSWORD: ${{ secrets.INFLUXDB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       # Label used to access the service container
       influxdb:
         # Docker Hub image
-        image: influxdb
+        image: influxdb:2.4 #currently we are using 2.4 for testing purposes
         # Provide the password 
         env:
           DOCKER_INFLUXDB_INIT_MODE: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           DOCKER_INFLUXDB_INIT_BUCKET: some_bucket
           DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${{ secrets.INFLUXDB_TOKEN }}
         ports:
-          # Maps tcp port 5432 on service container to the host
+          # Maps tcp port on service container to the host
           - 8086:8086
 
     steps:    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
       # Label used to access the service container
       influxdb:
         # Docker Hub image
-        image: influxdb:2.4 #currently we are using 2.4 for testing purposes
+        image: influxdb:2.4 #currently we are using 2.4 for testing purposes, 
+        #WARN: github CI seems to fail on 2.6. Unclear if the API changed or maybe HTTPS is required for newer versions (or https is disabled?)
         # Provide the password 
         env:
           DOCKER_INFLUXDB_INIT_MODE: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         version:
           - '1.8'
-          - '1' # automatically expands to the latest stable 1.x release of Julia
+          - '1.6' # automatically expands to the latest stable 1.6.x release of Julia
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 #influx command to create all access token - > then write to env variable.
 #influx auth create --org my-org --all-access
-#
-# 
+ 
 name: CI
 on:
   pull_request:
@@ -12,7 +11,6 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    container: ubuntu
     strategy:
       fail-fast: false
       matrix:
@@ -70,4 +68,3 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           files: lcov.info
-  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           #must include PORT too here:
           #The hostname of the PostgreSQL service is the label you configured in your workflow, in this case, postgres. Because Docker containers on the same user-defined bridge network open all ports by default, you'll be able to access the service container on the default PostgreSQL port 5432.
           INFLUXDB_HOST: localhost:8086
-          INFLUXDB_URL: https://localhost:8086
+          INFLUXDB_URL: http://localhost:8086
           INFLUXDB_ORG: ${{ secrets.INFLUXDB_ORG }}
           INFLUXDB_USER: ${{ secrets.INFLUXDB_USER }}
           INFLUXDB_PASSWORD: ${{ secrets.INFLUXDB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
           JULIA_NUM_THREADS: 4          
           #must include PORT too here:
           #The hostname of the PostgreSQL service is the label you configured in your workflow, in this case, postgres. Because Docker containers on the same user-defined bridge network open all ports by default, you'll be able to access the service container on the default PostgreSQL port 5432.
-          #INFLUXDB_HOST: localhost:8086
           INFLUXDB_HOST: localhost:8086
+          INFLUXDB_URL: https://localhost:8086
           INFLUXDB_ORG: ${{ secrets.INFLUXDB_ORG }}
           INFLUXDB_USER: ${{ secrets.INFLUXDB_USER }}
           INFLUXDB_PASSWORD: ${{ secrets.INFLUXDB_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    container: ubuntu
     strategy:
       fail-fast: false
       matrix:
@@ -59,8 +60,8 @@ jobs:
           JULIA_NUM_THREADS: 4          
           #must include PORT too here:
           #The hostname of the PostgreSQL service is the label you configured in your workflow, in this case, postgres. Because Docker containers on the same user-defined bridge network open all ports by default, you'll be able to access the service container on the default PostgreSQL port 5432.
-          INFLUXDB_HOST: 0.0.0.0:8086
-          INFLUXDB_URL: http://0.0.0.0:8086
+          INFLUXDB_HOST: localhost:8086
+          INFLUXDB_URL: http://localhost:8086
           INFLUXDB_ORG: ${{ secrets.INFLUXDB_ORG }}
           INFLUXDB_USER: ${{ secrets.INFLUXDB_USER }}
           INFLUXDB_PASSWORD: ${{ secrets.INFLUXDB_PASSWORD }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InfluxDBClient"
 uuid = "7a087161-7d97-4627-bbdd-0c82161d9408"
-authors = ["bernhard.koenig"]
-version = "0.0.5"
+authors = ["bernhard.koenig", "marius.kruger"]
+version = "0.0.6"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ For more information, see:
     <https://discourse.julialang.org/t/activating-test-dependencies/48121/10>
     <https://github.com/JuliaTesting/TestEnv.jl>
 
-also had to modify runtents.jl line 47 to not add "test/"
+also had to modify runtents.jl line 55 to not add "test/"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ There are three optoins to configure the database access (see function `get_sett
 1) environment variables
 * ENV["INFLUXDB_ORG"] the organization
 * ENV["INFLUXDB_TOKEN"] the token to access the InfluxDB
-* ENV["INFLUXDB_HOST"] should include the port, e.g. "10.14.15.10:8086"
+* ENV["INFLUXDB_URL"] should include protocol and the port, e.g. "http://10.14.15.10:8086"
+  or with https e.g. `ENV["INFLUXDB_URL"]="https://us-east-1-1.aws.cloud2.influxdata.com:443"`
+
 2) keyword argumetns to `get_settings`
 3) provide a space delimited file to `get_settings`
 
@@ -52,7 +54,7 @@ using DataFrames
 a_random_bucket_name = "test_InfluxDBClient.jl_asdfeafdfasefsIyxdFDYfadsfasdfa____l"
 
 #isettings should return a NamedTuple similar to 
-#(INFLUXDB_HOST = "10.14.15.10:8086", INFLUXDB_ORG = "bk", INFLUXDB_TOKEN = "5Ixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==")
+#(INFLUXDB_URL = "http://10.14.15.10:8086", INFLUXDB_ORG = "bk", INFLUXDB_TOKEN = "5Ixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==")
 isettings = get_settings()
 
 #check if the InfluxDB is reachable
@@ -109,7 +111,7 @@ delete_bucket(isettings,a_random_bucket_name)
 First make sure you have the following environment variables defined:
 
 ```Julia
-ENV["INFLUXDB_HOST"]="localhost:8086"
+ENV["INFLUXDB_URL"]="http://localhost:8086"
 ENV["INFLUXDB_ORG"]="<some org>"
 ENV["INFLUXDB_TOKEN"]="5Ixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=="
 ENV["INFLUXDB_USER"]="<admin user>"

--- a/config_host_example.txt
+++ b/config_host_example.txt
@@ -1,4 +1,4 @@
-INFLUXDB_URL http://10.14.15.10:8086
+INFLUXDB_HOST 10.14.15.10:8086
 INFLUXDB_ORG bk
 INFLUXDB_TOKEN 5xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxoA==
 INFLUXDB_USER bernhard

--- a/dev/readme_code.jl
+++ b/dev/readme_code.jl
@@ -5,7 +5,7 @@ using DataFrames
 a_random_bucket_name = "test_InfluxDBClient.jl_asdfeafdfasefsIyxdFDYfadsfasdfa____l"
 
 #isettings should return a NamedTuple similar to 
-#(INFLUXDB_HOST = "10.14.15.10:8086", INFLUXDB_ORG = "bk", INFLUXDB_TOKEN = "5Ixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==")
+#(INFLUXDB_URL = "http://10.14.15.10:8086", INFLUXDB_ORG = "bk", INFLUXDB_TOKEN = "5Ixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==")
 isettings = get_settings()
 
 #check if the InfluxDB is reachable

--- a/src/delete.jl
+++ b/src/delete.jl
@@ -9,12 +9,12 @@ function delete(isettings,bucket::String;measurement::String="",start::Union{Dat
     #=
          bucket = a_random_bucket_name
     =#
-    @unpack INFLUXDB_HOST,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
+    @unpack INFLUXDB_URL,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
     organization_names,jsonORG = get_organizations(isettings)
     ORG_ID = get_orgid(jsonORG,INFLUXDB_ORG)
 
     hdrs = Dict("Authorization" => "Token $(INFLUXDB_TOKEN)", "Content-Type"=>"application/json")
-    url = """http://$(INFLUXDB_HOST)/api/v2/delete?org=$INFLUXDB_ORG&bucket=$bucket"""
+    url = """$(INFLUXDB_URL)/api/v2/delete?org=$INFLUXDB_ORG&bucket=$bucket"""
 
     if isa(start,DateTime) 
         start = string(start,"Z")

--- a/src/query.jl
+++ b/src/query.jl
@@ -52,6 +52,10 @@ function query_flux_postprocess_response(bdy,parse_datetime,datetime_precision,t
         return df 
     end
     
+    # influx sometimes returns extra header rows that ends up in our data :'(
+    # https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/?t=Different+schema#csv-response-format
+    filter!(:_time => !=("_time"), df)
+    
     DataFrames.select!(df,Not(:Column1)) #unclear what this could/would be (let us drop it for now)
 
     if parse_datetime

--- a/src/query.jl
+++ b/src/query.jl
@@ -3,8 +3,6 @@
 
 export query_flux
 
-
-
 """
     query_flux(isettings,bucket,measurement;parse_datetime=false,datetime_precision="ns",tzstr = "UTC",range=Dict{String,Any}(),fields::Vector{String}=String[],tags=Dict{String,Any}(),aggregate::String="")
     

--- a/src/query.jl
+++ b/src/query.jl
@@ -118,7 +118,7 @@ function query_flux_http_response(isettings,bucket,measurement;range=Dict{String
         measurement = "my_meas"
     =#
 
-    @unpack INFLUXDB_HOST,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
+    @unpack INFLUXDB_URL,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
     
     #@assert length(range) > 0 #I think this may be necessary for any query...
     rngstr = ""
@@ -197,10 +197,10 @@ function query_flux_http_response(isettings,bucket,measurement;range=Dict{String
 end 
 
 function query_flux(isettings,q::String)
-    @unpack INFLUXDB_HOST,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
+    @unpack INFLUXDB_URL,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
     
     hdrs = Dict("Authorization" => "Token $(INFLUXDB_TOKEN)", "Accept"=>"application/json","Content-Type"=>"application/vnd.flux; charset=utf-8","Content-Encoding" => "identity")    
-    url = """http://$(INFLUXDB_HOST)/api/v2/query?org=$INFLUXDB_ORG"""
+    url = """$(INFLUXDB_URL)/api/v2/query?org=$INFLUXDB_ORG"""
     bdy = q
     #@show q
 

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -44,16 +44,11 @@ function _update_setting_keys(isettings::Dict{String,String})
     delete!(isettings, "INFLUXDB_HOST")
     
     isettings["INFLUXDB_ORG"] = replace(isettings["INFLUXDB_ORG"], " " => "%20") 
-    isettings
+    return isettings
 end
 
 export get_settings_from_file
 function get_settings_from_file(;file="")
-    #=
-    
-    fi = raw"
-    =#
-
     isettings = Dict{String,String}()
 
     @show file

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -1,24 +1,25 @@
 export get_settings
-function get_settings(;org::String="",token::String="",host::String="",user::String="",password::String="",file::String="") #,bucket::String="")
+function get_settings(;org::String="",token::String="",url::String="",host::String="",user::String="",password::String="",file::String="") #,bucket::String="")
 
     #maybe add an option to use something along ~/.influxdbconfig ? 
     if length(file)>0
         settings_from_file = get_settings_from_file(;file=file)
-        return settings_from_file
+        return _update_setting_keys(settings_from_file)
     else 
         settings_from_file = Dict{String,String}()
     end
     
     envsettings = Dict{String,String}()
-    for k in ["INFLUXDB_PASSWORD","INFLUXDB_USER","INFLUXDB_HOST","INFLUXDB_TOKEN","INFLUXDB_ORG"]
+    for k in ["INFLUXDB_PASSWORD","INFLUXDB_USER","INFLUXDB_URL","INFLUXDB_HOST","INFLUXDB_TOKEN","INFLUXDB_ORG"]
         if haskey(ENV,k)
-         envsettings[k] = ENV[k]
+            envsettings[k] = ENV[k]
         end
     end
 
     #kwargs should 'overwrite' environment variables
     kwsettings = envsettings 
     if length(org) > 0; kwsettings["INFLUXDB_ORG"] = org; end;
+    if length(url) > 0; kwsettings["INFLUXDB_URL"] = url; end;
     if length(host) > 0; kwsettings["INFLUXDB_HOST"] = host; end;
     if length(token) > 0 ; kwsettings["INFLUXDB_TOKEN"] = token; end;
     if length(user) > 0 ; kwsettings["INFLUXDB_USER"] = user; end;
@@ -32,7 +33,18 @@ function get_settings(;org::String="",token::String="",host::String="",user::Str
 
     #isettings=Dict{String,String}("INFLUXDB_HOST"=>host,"INFLUXDB_ORG"=>org,"INFLUXDB_TOKEN"=>token,"INFLUXDB_USER"=>user,"INFLUXDB_PASSWORD"=>password)
 
-    return isettings
+    return _update_setting_keys(isettings)
+end
+
+function _update_setting_keys(isettings::Dict{String,String})
+    if !haskey(isettings, "INFLUXDB_URL")
+        # support INFLUXDB_HOST for backward compatibility
+        isettings["INFLUXDB_URL"] = "http://" * isettings["INFLUXDB_HOST"]
+    end
+    delete!(isettings, "INFLUXDB_HOST")
+    
+    isettings["INFLUXDB_ORG"] = replace(isettings["INFLUXDB_ORG"], " " => "%20") 
+    isettings
 end
 
 export get_settings_from_file

--- a/src/write.jl
+++ b/src/write.jl
@@ -44,7 +44,7 @@ function write_data(isettings,bucket::String,payload::Union{String,Vector{UInt8}
                 airSensors,sensor_id=TLM0202 temperature=72.30007505999716,humidity=30.651929918691714,co=0.6141876544505826 1630424259000000000"""
     =#
 
-    @unpack INFLUXDB_HOST,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
+    @unpack INFLUXDB_URL,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
         
     if !bucket_exists(isettings,bucket)
         throw(ArgumentError("Bucket $bucket does  not exist"))
@@ -61,7 +61,7 @@ function write_data(isettings,bucket::String,payload::Union{String,Vector{UInt8}
     
     #To send a line protocol payload, pass Content-Type: text/plain; charset=utf-8.    
     hdrs = Dict("Authorization" => "Token $(INFLUXDB_TOKEN)", "Accept"=>"application/json","Content-Type"=>"application/json; charset=utf-8")
-    url = """http://$(INFLUXDB_HOST)/api/v2/write?org=$INFLUXDB_ORG&bucket=$bucket&precision=$influx_precision"""
+    url = """$(INFLUXDB_URL)/api/v2/write?org=$INFLUXDB_ORG&bucket=$bucket&precision=$influx_precision"""
     #@show typeof(payload)
     if compress
         #gzip

--- a/test/delete.jl
+++ b/test/delete.jl
@@ -18,13 +18,13 @@ curl --request POST http://localhost:8086/api/v2/delete?org=example-org&bucket=e
 
     #buckets,_ = get_buckets(isettings;limit=100,offset=0)
     bucket = a_random_bucket_name
-    @unpack INFLUXDB_HOST,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
+    @unpack INFLUXDB_URL,INFLUXDB_TOKEN,INFLUXDB_ORG = isettings
     organization_names,jsonORG = get_organizations(isettings)
     ORG_ID = get_orgid(jsonORG,INFLUXDB_ORG)
     gzip_compression_is_enabled = false
 
     hdrs = Dict("Authorization" => "Token $(INFLUXDB_TOKEN)", "Content-Type"=>"application/json")
-    url = """http://$(INFLUXDB_HOST)/api/v2/delete?org=$INFLUXDB_ORG&bucket=$bucket"""
+    url = """$(INFLUXDB_URL)/api/v2/delete?org=$INFLUXDB_ORG&bucket=$bucket"""
     content = """{"name": "$bucket", "orgID": "$ORG_ID"}"""
     
     payload_to_write = """airSensors,sensor_id=TLM0201 temperature=73.97038159354763,humidity=35.23103248356096,co=0.48445310567793615 1630424257000000000

--- a/test/large_data.jl
+++ b/test/large_data.jl
@@ -20,7 +20,7 @@
     
     lp = lineprotocol("my_meas",df,["temperature","an_int_value","abool","humidity"],tags=["color","sensor_id"], :datetime);
     @time write_data(isettings,a_random_bucket_name,lp,"ns")
-    @test length(findall('\n',lp)) == nn - 1 #only works if data has no \n
+    @test length(findall("\n",lp)) == nn - 1 #only works if data has no \n
     
     ########################################################################
     #batch processing data

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -33,7 +33,7 @@
     for measurement in measurements
         fields = query_measurement_field_keys(isettings, a_random_bucket_name, measurement)
         #on my local machine this vector is empty, not sure why
-        @warn("may need to improve this")
+        @warn("may need to improve this test")
         @show fields
         println("$measurement : $(join(fields, ", "))")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ end
 #smoketest 1 to see if DB is up
 #a get request to """$(INFLUXDB_URL)/metrics""" is another possibility to check if the server is up
 try 
-    metrics_url = """http://$(isettings["INFLUXDB_URL"])/metrics"""
+    metrics_url = """$(isettings["INFLUXDB_URL"])/metrics"""
     @info("Trying to query $(metrics_url)...")
     r = HTTP.request("GET", metrics_url,status_exception = false)
     #maybe status is 200 when metrics are ENABLED and status is 403 when metrics are DISABLED
@@ -35,7 +35,7 @@ try
     @info("Status is $(r.status)")
     @info("Body is $(String(r.body))")
 catch er
-    @warn("failed to query: http://$(isettings["INFLUXDB_URL"])/metrics")
+    @warn("failed to query: $(isettings["INFLUXDB_URL"])/metrics")
     @show er
 end
 
@@ -52,7 +52,7 @@ catch
 end;
 @test length(bucket_names) > 0
 @show bucket_names
-prefix = ifelse(isinteractive() , "", "")
+prefix = ifelse(isinteractive() , "test/", "")
 include(string(prefix,"functions.jl"))
 
 nmax_repeat_selected_query_tests = 2 #(haskey(ENV,"USERPROFILE")&&endswith(ENV["USERPROFILE"],"konig")) ? 2 : 20

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,9 +25,9 @@ end
 @test length(a_random_bucket_name) > 0
 
 #smoketest 1 to see if DB is up
-#a get request to """http://$(INFLUXDB_HOST)/metrics""" is another possibility to check if the server is up
+#a get request to """$(INFLUXDB_URL)/metrics""" is another possibility to check if the server is up
 try 
-    metrics_url = """http://$(isettings["INFLUXDB_HOST"])/metrics"""
+    metrics_url = """http://$(isettings["INFLUXDB_URL"])/metrics"""
     @info("Trying to query $(metrics_url)...")
     r = HTTP.request("GET", metrics_url,status_exception = false)
     #maybe status is 200 when metrics are ENABLED and status is 403 when metrics are DISABLED
@@ -35,7 +35,7 @@ try
     @info("Status is $(r.status)")
     @info("Body is $(String(r.body))")
 catch er
-    @warn("failed to query: http://$(isettings["INFLUXDB_HOST"])/metrics")
+    @warn("failed to query: http://$(isettings["INFLUXDB_URL"])/metrics")
     @show er
 end
 
@@ -52,7 +52,7 @@ catch
 end;
 @test length(bucket_names) > 0
 @show bucket_names
-prefix = ifelse(isinteractive() , "test/", "")
+prefix = ifelse(isinteractive() , "", "")
 include(string(prefix,"functions.jl"))
 
 nmax_repeat_selected_query_tests = 2 #(haskey(ENV,"USERPROFILE")&&endswith(ENV["USERPROFILE"],"konig")) ? 2 : 20

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,18 +41,14 @@ end
 
 #smoketest 2 to see if DB is up
 #https://docs.influxdata.com/influxdb/v2.4/write-data/developer-tools/api/
-bucket_names,json = try
-    try
-        get_buckets(isettings); #1.7 ms btime, (influxdb host is on a different machine)
-    catch er
-        @show er
-        "","";
-    end
-catch
-    "","";
-end;
-@test length(bucket_names) > 0
-@show bucket_names
+try
+    bucket_names, json = get_buckets(isettings); #1.7 ms btime, (influxdb host is on a different machine)
+    @test length(bucket_names) > 0
+    @show bucket_names
+catch er
+    @warn("failed to get list of buckets. InfluxDB may not be reachable.")
+    @show er
+end
 prefix = ifelse(isinteractive() , "test/", "")
 include(string(prefix,"functions.jl"))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,17 +41,17 @@ end
 
 #smoketest 2 to see if DB is up
 #https://docs.influxdata.com/influxdb/v2.4/write-data/developer-tools/api/
-bucket_names = "" 
+bucket_names = ""
 json = ""
 try
-    bucket_names, json = get_buckets(isettings); #1.7 ms btime, (influxdb host is on a different machine)
+    global bucket_names, json = get_buckets(isettings); #1.7 ms btime, (influxdb host is on a different machine)
     @test length(bucket_names) > 0
     @show bucket_names
 catch er
     @warn("failed to get list of buckets. InfluxDB may not be reachable.")
     @show er
-    bucket_names = "" 
-    json = ""
+    global bucket_names = "" 
+    global json = ""
 end
 prefix = ifelse(isinteractive() , "test/", "")
 include(string(prefix,"functions.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,8 @@ end
 
 #smoketest 2 to see if DB is up
 #https://docs.influxdata.com/influxdb/v2.4/write-data/developer-tools/api/
+bucket_names = "" 
+json = ""
 try
     bucket_names, json = get_buckets(isettings); #1.7 ms btime, (influxdb host is on a different machine)
     @test length(bucket_names) > 0
@@ -48,6 +50,8 @@ try
 catch er
     @warn("failed to get list of buckets. InfluxDB may not be reachable.")
     @show er
+    bucket_names = "" 
+    json = ""
 end
 prefix = ifelse(isinteractive() , "test/", "")
 include(string(prefix,"functions.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ bucket_names,json = try
         get_buckets(isettings); #1.7 ms btime, (influxdb host is on a different machine)
     catch er
         @show er
+        "","";
     end
 catch
     "","";

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,10 @@ try
     #maybe status is 200 when metrics are ENABLED and status is 403 when metrics are DISABLED
     @test in(r.status,[200,403])
     @info("Status is $(r.status)")
-    @info("Body is $(String(r.body))")
+    strbdy = String(r.body)
+    if length(strbdy) < 200
+        @info("Body is $(String(r.body))")
+    end
 catch er
     @warn("failed to query: $(isettings["INFLUXDB_URL"])/metrics")
     @show er

--- a/test/settings.jl
+++ b/test/settings.jl
@@ -1,17 +1,27 @@
 
 @testset "Settings.jl                    " begin
 
-    fi = normpath(joinpath(pathof(InfluxDBClient),"..","..","config_example.txt"))
-  @test isfile(fi)
+    config_example_file = normpath(joinpath(pathof(InfluxDBClient),"..","..","config_example.txt"))
+    @test isfile(config_example_file)
+    config_host_example_file = normpath(joinpath(pathof(InfluxDBClient),"..","..","config_host_example.txt"))
+    @test isfile(config_host_example_file)
 
-    senv = get_settings()
-    s = get_settings(file=fi)
-    sfi = get_settings_from_file(file=fi)
+    s_env = get_settings()
+    s_config_example_file = get_settings(file=config_example_file)
+    s_from_config_example_file = get_settings_from_file(file=config_example_file)
+
+    s_config_host_example_file = get_settings(file=config_host_example_file)
+    s_from_config_host_example_file = get_settings_from_file(file=config_host_example_file)
+
+    for k in ["INFLUXDB_USER", "INFLUXDB_TOKEN", "INFLUXDB_URL", "INFLUXDB_PASSWORD", "INFLUXDB_ORG"]
+        @test haskey(s_env, k)
+        @test haskey(s_config_example_file, k)
+        @test haskey(s_from_config_example_file, k)
+        @test haskey(s_config_host_example_file, k)
+    end
 
     for k in ["INFLUXDB_USER", "INFLUXDB_TOKEN", "INFLUXDB_HOST", "INFLUXDB_PASSWORD", "INFLUXDB_ORG"]
-        @test haskey(senv,k)
-        @test haskey(s,k)
-        @test haskey(sfi,k)
-    end
+      @test haskey(s_from_config_host_example_file, k)
+  end
         
 end


### PR DESCRIPTION
hi, 
I'd like to use this library to connect to influxdb cloud,  but for that I need https support, so I gave that a go.
In order to be backwards compatible but still allow configuring an https url, I suggest we move away from INFLUXDB_HOST to INFLUXDB_URL

I also fixed some bugs I ran into while testing this
* support influx org names that contain a space, by converting it to "%20"
* in query.jl line 57 I filter out lines where _time=_time apparently influx is happy to repeat headers:
![Selection_528](https://user-images.githubusercontent.com/849576/221692787-1c3b9820-7368-4d3e-acb5-bcdf58433ad7.png)

Let me know if you need me to change anything.
